### PR TITLE
Fix bug in isAlone function

### DIFF
--- a/avr/cores/AutomaTile/AutomaTile.c
+++ b/avr/cores/AutomaTile/AutomaTile.c
@@ -149,16 +149,14 @@ uint8_t getNeighbor(const uint8_t neighbor){
 
 bool isAlone(void){
 	uint8_t neighbors[TILE_SIDES];
-	bool alone = true;
 	getNeighborStates(neighbors);
 	uint8_t i;
 	for(i=0; i<TILE_SIDES; i++){
-		if (neighbors[TILE_SIDES]){
-			alone =  false;
-			break;
+		if (neighbors[i]){
+			return( false );
 		}
 	}
-	return alone;
+	return true;
 }
 
 uint32_t getTimer(){


### PR DESCRIPTION
Array index in isAlone() was wrong and would not return correct result (and was actually a buffer overrrun).